### PR TITLE
Renamed WACZ column header to View

### DIFF
--- a/assets/js/archives.js
+++ b/assets/js/archives.js
@@ -14,7 +14,7 @@ async function main() {
   addCell(hdr, "Title", "th");
   addCell(hdr, "URL", "th");
   addCell(hdr, "Description", "th");
-  addCell(hdr, "WACZ", "th");
+  addCell(hdr, "View", "th");
   table.appendChild(hdr);
 
   for (const row of reader.rows) {


### PR DESCRIPTION
A very small change since the WACZ column header seemed redundant with all the WACZ icons.