### PR TITLE
Update include URL regex

### DIFF
--- a/browsertrix.md
+++ b/browsertrix.md
@@ -75,7 +75,8 @@ workers: 16
 saveState: always
 seeds:
   - url: http://sgiaz.uamuseum.com/
-    include: .*\.sgiaz\.uamuseum\.com/
+    include: 
+      - ^(http|https):.*sgiaz\.uamuseum\.com
     scopeType: "host"
 ```
 


### PR DESCRIPTION
Update include URL to match http(s) changes and subdomains, so it will match:
https://sgiaz.uamuseum.com/
http://sgiaz.uamuseum.com/
http://sub.sgiaz.uamuseum.com/
http://www.sgiaz.uamuseum.com/

But not match:
http://sgiaz.uamuseum.attack-vector.com/

(Current example does not match http/https changes nor redirects to domains without (www.) prefix, e.g. http://www.important.ua -> http://important.ua)