### PR TITLE
WACZ links

### DIFF
--- a/assets/js/archives.js
+++ b/assets/js/archives.js
@@ -70,7 +70,11 @@ function viewArchiveIcon(archiveUrl, websiteUrl) {
     link.href = archiveUrl;
     img.src = "/assets/images/ia.png";
   } else if (archiveUrl.match(/wacz$/)) {
-    link.href = `https://replayweb.page/?source=${archiveUrl}#view=pages&url=${websiteUrl}`;
+    if (archiveUrl.match(/replayweb/)) {
+      link.href = archiveUrl;
+    } else {
+      link.href = `https://replayweb.page/?source=${archiveUrl}#view=pages&url=${websiteUrl}`;
+    }
     img.src = "/assets/images/wacz.png";
   } else {
     // didn't recognize the archive link!


### PR DESCRIPTION
This commit fixes the display of WACZ archive URLs that are not to the
actual WACZ but to the replayweb viewer.
